### PR TITLE
Add Dockerfile and convenience scripts for backend deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+EXPOSE 3000
+COPY . /root/Doacoes
+RUN  apk add git npm vim bash
+WORKDIR /root/Doacoes
+RUN npm install --force
+ENV DATABASE_URL="postgresql://postgres:concatto@db.aandre.de:5150/doacao"
+ENTRYPOINT ["npm"]
+CMD ["run","dev"]

--- a/buildimage.sh
+++ b/buildimage.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+DCKR=$(which podman docker | head -n 1)
+
+$DCKR build -t extbackend:latest .
+

--- a/runbackend.sh
+++ b/runbackend.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+DCKR=$(which podman docker | head -n 1)
+
+$DCKR run --rm -it -p 3000:3000 extbackend:latest


### PR DESCRIPTION
In it's current state, the backend doesn't exactly work out of the box. This patch adds a Dockerfile, plus some scripts, to streamline this process.

Note que para user o Docker file, primeiro deve-se compila-lo usando a script `buildimage.sh`, então deve-se rodar o container com `runbackend.sh`.